### PR TITLE
Fixing rebuild to load all the needed files

### DIFF
--- a/ddkits.alias.sh
+++ b/ddkits.alias.sh
@@ -130,6 +130,7 @@ ddk(){
   elif [[ $1 == "rebuild" ]]; then
       clear
         cat "./ddkits-files/ddkits/logo.txt"
+        source ddkits-files/ddkitsInfo.dev.sh ddkits-files/ddkitsInfo.ports.sh ddkits-files/ddkitscli.sh ~/.ddkits_alias ~/.ddkits_alias_web
         docker-compose -f ddkitsnew.yml -f ddkits.env.yml up -d --build --force-recreate
   elif [[ $1 == "start" ]]; then
       if [[ $2 == "com" ]]; then


### PR DESCRIPTION
Only ddk rebuild will rebuild any system from the root folder